### PR TITLE
Remove 'NEW' badge from Community menu link

### DIFF
--- a/templates/home.pug
+++ b/templates/home.pug
@@ -107,7 +107,7 @@ html(lang=language)
         li#menu-tutorials(title=translator.get("Tutorials")) <i class="fa fa-lightbulb"></i><br /><span>#{translator.get("Tutorials")}</span>
         li#menu-help(title=translator.get("Documentation")) <i class="fa fa-book-open"></i><br /><span>#{translator.get("Documentation")}</span>
         a(target="_blank" href=language == "fr" ? "/fr/community/" : "/community/")
-          li#menu-community(title=translator.get("Community")) <i class="fa fa-users"></i><br /><span>#{translator.get("Community")}</span> <span class="pastille">NEW</span>
+          li#menu-community(title=translator.get("Community")) <i class="fa fa-users"></i><br /><span>#{translator.get("Community")}</span>
         li#menu-about(title=translator.get("About")) <i class="fa fa-info-circle"></i><br /><span>#{translator.get("About")}</span><i class="fab fa-patreon"></i>
 
     div.usermenu(style="height:0px;")


### PR DESCRIPTION
Community was introduced in March, so I believe it is not so 'NEW' anymore. :D