### PR TITLE
Autofocus title input when creating new project

### DIFF
--- a/static/js/appui/appui.coffee
+++ b/static/js/appui/appui.coffee
@@ -53,6 +53,7 @@ class AppUI
 
     @setAction "create-project-button",()=>
       @show "create-project-overlay"
+      @focus "create-project-title"
 
     @setAction "create-project-window",(event)=>
       event.stopPropagation()
@@ -301,6 +302,9 @@ class AppUI
 
   setDisplay:(element,value)->
     document.getElementById(element).style.display = value
+
+  focus:(element)->
+    document.getElementById(element).focus()
 
   get:(id)->
     document.getElementById(id)

--- a/static/js/appui/appui.js
+++ b/static/js/appui/appui.js
@@ -53,7 +53,8 @@ AppUI = (function() {
     this.createLoginFunctions();
     this.setAction("create-project-button", (function(_this) {
       return function() {
-        return _this.show("create-project-overlay");
+        _this.show("create-project-overlay");
+        return _this.focus("create-project-title");
       };
     })(this));
     this.setAction("create-project-window", (function(_this) {
@@ -395,6 +396,10 @@ AppUI = (function() {
 
   AppUI.prototype.setDisplay = function(element, value) {
     return document.getElementById(element).style.display = value;
+  };
+
+  AppUI.prototype.focus = function(element) {
+    return document.getElementById(element).focus();
   };
 
   AppUI.prototype.get = function(id) {


### PR DESCRIPTION
Currently, when you press the "Create new project" button, you have to click on the input field to write and give your game a title. I changed it, so that the input field for title is autofocued right after the popup shows up and you can start writing without touching the mouse again.