### PR TITLE
Feature/import project

### DIFF
--- a/server/ratelimiter.coffee
+++ b/server/ratelimiter.coffee
@@ -13,6 +13,7 @@ class @RateLimiter
     @map.create_account_ip = new RateLimiterClass(@,30,30) # 30 comptes pour 30 minutes => classroom check
 
     @map.create_project_user = new RateLimiterClass(@,60,10) # max 10 projects per hour
+    @map.import_project_user = new RateLimiterClass(@,60,10) # max 10 projects per hour
 
     @map.create_file_user = new RateLimiterClass(@,5,40) # max 40 new files per 5 minutes
     #@map.change_file_user = new RateLimiterClass(@,10,200)

--- a/server/ratelimiter.js
+++ b/server/ratelimiter.js
@@ -11,6 +11,7 @@ this.RateLimiter = (function() {
     this.map.send_mail_user = new RateLimiterClass(this, 5, 5);
     this.map.create_account_ip = new RateLimiterClass(this, 30, 30);
     this.map.create_project_user = new RateLimiterClass(this, 60, 10);
+    this.map.import_project_user = new RateLimiterClass(this, 60, 10);
     this.map.create_file_user = new RateLimiterClass(this, 5, 40);
     this.map.post_comment_user = new RateLimiterClass(this, 10, 10);
     this.map.create_forum_post = new RateLimiterClass(this, 60, 10);

--- a/server/session/session.coffee
+++ b/server/session/session.coffee
@@ -398,9 +398,8 @@ class @Session
             files = []
             for filename, value of contents.files
               files.push filename
-            console.log "[ZIP] Files added the list. Amount of files: #{files.length}"
+
             funk = () =>
-              console.log "[ZIP] Files to process: #{files.length}"
               if files.length > 0
                 filename = files.splice(0,1)[0]
                 value = contents.files[filename]
@@ -414,7 +413,7 @@ class @Session
                     properties: properties,
                     request_id: request_id
                   }
-                  console.log "[ZIP] Processing file: #{filename}"
+
                   if value.dir
                     funk()
                   else if filename == projectFileName
@@ -432,7 +431,6 @@ class @Session
                   else
                     @unzipAndWriteProjectFile(zip, import_data, "base64", ()=> funk())
               else
-                console.log "[ZIP] All files processed!"
                 @send
                   name:"project_imported"
                   id: project_id
@@ -451,7 +449,6 @@ class @Session
           properties: import_data.properties
         }
         @writeProjectFile(writeData)
-        console.log "Unzipped and written file: #{import_data.filename}"
         callback() if callback?
     catch err
       console.error err
@@ -462,7 +459,6 @@ class @Session
       zip.file(import_data.filename).async(type).then (fileContent) =>
         buffer = Buffer.from(fileContent, "base64");
         @content.files.write "#{@user.id}/#{import_data.project_id}/#{import_data.filename}", buffer, () ->
-          console.log "Unzipped and created file: #{import_data.filename}"
           callback() if callback?
     catch err
       console.error err

--- a/server/session/session.coffee
+++ b/server/session/session.coffee
@@ -385,6 +385,10 @@ class @Session
     queue = new JobQueue ()=>
       zip = new JSZip
       zip.loadAsync(buffer).then (contents) =>
+        if not zip.file("project.meta")?
+          console.log "[ZIP] Missing project.meta; import aborted"
+          return
+
         zip.file("project.meta").async("string").then (text) =>
           projectInfo = JSON.parse(text)
           @content.createProject @user,projectInfo,(project)=>

--- a/server/session/session.coffee
+++ b/server/session/session.coffee
@@ -380,6 +380,7 @@ class @Session
   importProject:(data)->
     return @sendError("not connected") if not @user?
     return if not @server.rate_limiter.accept("import_project_user",@user.id)
+    return if not data.zip_data.startsWith("data:application/x-zip-compressed;base64,")
     buffer = new Buffer.from(data.zip_data.replace("data:application/x-zip-compressed;base64,", ""), 'base64');
     queue = new JobQueue ()=>
       zip = new JSZip

--- a/server/session/session.coffee
+++ b/server/session/session.coffee
@@ -432,25 +432,25 @@ class @Session
     console.log filename
     try
       zip.file(filename).async(type).then (fileContent) =>
-         writeUnziipedFile = (properties) =>
-          writeData = {
-            project: project.id
-            file: filename
-            content: fileContent
-            request_id: -data.request_id
-            properties: properties
-          }
-          @writeProjectFile(writeData)
-          console.log "Unzipped and written file: #{filename}"
-          callback() if callback?
         try
+          writeUnzippedFile = (properties) =>
+            writeData = {
+              project: project.id
+              file: filename
+              content: fileContent
+              request_id: -data.request_id
+              properties: properties
+            }
+            @writeProjectFile(writeData)
+            console.log "Unzipped and written file: #{filename}"
+            callback() if callback?
           if zip.file("#{filename}.meta")?
             zip.file("#{filename}.meta").async("string").then (meta) =>
               metaJson = JSON.parse(meta)
-              writeUnziipedFile(metaJson.properties)
+              writeUnzippedFile(metaJson.properties)
           else
             console.log "Meta file for file #{filename} does not exist, no properties added to the file"
-            writeUnziipedFile({})
+            writeUnzippedFile({})
         catch err
           console.error err
           console.log "#{filename}.meta"

--- a/server/session/session.coffee
+++ b/server/session/session.coffee
@@ -428,19 +428,25 @@ class @Session
     console.log filename
     try
       zip.file(filename).async(type).then (fileContent) =>
+         writeUnziipedFile = (properties) =>
+          writeData = {
+            project: project.id
+            file: filename
+            content: fileContent
+            request_id: -data.request_id
+            properties: properties
+          }
+          @writeProjectFile(writeData)
+          console.log "Unzipped and written file: #{filename}"
+          callback() if callback?
         try
-          zip.file("#{filename}.meta").async("string").then (meta) =>
-            metaJson = JSON.parse(meta)
-            writeData = {
-              project: project.id
-              file: filename
-              content: fileContent
-              request_id: -data.request_id
-              properties: metaJson.properties
-            }
-            @writeProjectFile(writeData)
-            console.log "Unzipped and written file: #{filename}"
-            callback() if callback?
+          if zip.file("#{filename}.meta")?
+            zip.file("#{filename}.meta").async("string").then (meta) =>
+              metaJson = JSON.parse(meta)
+              writeUnziipedFile(metaJson.properties)
+          else
+            console.log "Meta file for file #{filename} does not exist, no properties added to the file"
+            writeUnziipedFile({})
         catch err
           console.error err
           console.log "#{filename}.meta"

--- a/server/session/session.coffee
+++ b/server/session/session.coffee
@@ -402,6 +402,10 @@ class @Session
                       @unzipAndWriteProjectFile(zip, filename, project, data, "string")
                     else if filename.endsWith ".md"
                       @unzipAndWriteProjectFile(zip, filename, project, data, "string")
+                    else if filename.startsWith "sounds_th"
+                      @unzipAndCreateFile(zip, filename, project, data, "base64")
+                    else if filename.startsWith "music_th"
+                      @unzipAndCreateFile(zip, filename, project, data, "base64")
                     else 
                       @unzipAndWriteProjectFile(zip, filename, project, data, "base64")
 
@@ -426,6 +430,17 @@ class @Session
         catch err
           console.error err
           console.log "#{filename}.meta"
+    catch err
+      console.error err
+      console.log filename
+
+  unzipAndCreateFile:(zip, filename, project, data, type)->
+    console.log filename
+    try
+      zip.file(filename).async(type).then (fileContent) =>
+        buffer = Buffer.from(fileContent, "base64");
+        @content.files.write "#{@user.id}/#{project.id}/#{filename}", buffer
+        console.log filename
     catch err
       console.error err
       console.log filename

--- a/server/session/session.js
+++ b/server/session/session.js
@@ -764,44 +764,42 @@ this.Session = (function() {
     var err;
     console.log(filename);
     try {
-      zip.file(filename).async(type).then((function(_this) {
+      return zip.file(filename).async(type).then((function(_this) {
         return function(fileContent) {
-          var writeUnziipedFile;
-          return writeUnziipedFile = function(properties) {
-            var writeData;
-            writeData = {
-              project: project.id,
-              file: filename,
-              content: fileContent,
-              request_id: -data.request_id,
-              properties: properties
+          var err, writeUnzippedFile;
+          try {
+            writeUnzippedFile = function(properties) {
+              var writeData;
+              writeData = {
+                project: project.id,
+                file: filename,
+                content: fileContent,
+                request_id: -data.request_id,
+                properties: properties
+              };
+              _this.writeProjectFile(writeData);
+              console.log("Unzipped and written file: " + filename);
+              if (callback != null) {
+                return callback();
+              }
             };
-            _this.writeProjectFile(writeData);
-            console.log("Unzipped and written file: " + filename);
-            if (callback != null) {
-              return callback();
+            if (zip.file(filename + ".meta") != null) {
+              return zip.file(filename + ".meta").async("string").then(function(meta) {
+                var metaJson;
+                metaJson = JSON.parse(meta);
+                return writeUnzippedFile(metaJson.properties);
+              });
+            } else {
+              console.log("Meta file for file " + filename + " does not exist, no properties added to the file");
+              return writeUnzippedFile({});
             }
-          };
+          } catch (error1) {
+            err = error1;
+            console.error(err);
+            return console.log(filename + ".meta");
+          }
         };
       })(this));
-      try {
-        if (zip.file(filename + ".meta") != null) {
-          return zip.file(filename + ".meta").async("string").then((function(_this) {
-            return function(meta) {
-              var metaJson;
-              metaJson = JSON.parse(meta);
-              return writeUnziipedFile(metaJson.properties);
-            };
-          })(this));
-        } else {
-          console.log("Meta file for file " + filename + " does not exist, no properties added to the file");
-          return writeUnziipedFile({});
-        }
-      } catch (error1) {
-        err = error1;
-        console.error(err);
-        return console.log(filename + ".meta");
-      }
     } catch (error1) {
       err = error1;
       console.error(err);

--- a/server/session/session.js
+++ b/server/session/session.js
@@ -710,6 +710,10 @@ this.Session = (function() {
                         return _this.unzipAndWriteProjectFile(zip, filename, project, data, "string");
                       } else if (filename.endsWith(".md")) {
                         return _this.unzipAndWriteProjectFile(zip, filename, project, data, "string");
+                      } else if (filename.startsWith("sounds_th")) {
+                        return _this.unzipAndCreateFile(zip, filename, project, data, "base64");
+                      } else if (filename.startsWith("music_th")) {
+                        return _this.unzipAndCreateFile(zip, filename, project, data, "base64");
                       } else {
                         return _this.unzipAndWriteProjectFile(zip, filename, project, data, "base64");
                       }
@@ -752,6 +756,25 @@ this.Session = (function() {
             console.error(err);
             return console.log(filename + ".meta");
           }
+        };
+      })(this));
+    } catch (error1) {
+      err = error1;
+      console.error(err);
+      return console.log(filename);
+    }
+  };
+
+  Session.prototype.unzipAndCreateFile = function(zip, filename, project, data, type) {
+    var err;
+    console.log(filename);
+    try {
+      return zip.file(filename).async(type).then((function(_this) {
+        return function(fileContent) {
+          var buffer;
+          buffer = Buffer.from(fileContent, "base64");
+          _this.content.files.write(_this.user.id + "/" + project.id + "/" + filename, buffer);
+          return console.log(filename);
         };
       })(this));
     } catch (error1) {

--- a/server/session/session.js
+++ b/server/session/session.js
@@ -760,33 +760,44 @@ this.Session = (function() {
     var err;
     console.log(filename);
     try {
-      return zip.file(filename).async(type).then((function(_this) {
+      zip.file(filename).async(type).then((function(_this) {
         return function(fileContent) {
-          var err;
-          try {
-            return zip.file(filename + ".meta").async("string").then(function(meta) {
-              var metaJson, writeData;
-              metaJson = JSON.parse(meta);
-              writeData = {
-                project: project.id,
-                file: filename,
-                content: fileContent,
-                request_id: -data.request_id,
-                properties: metaJson.properties
-              };
-              _this.writeProjectFile(writeData);
-              console.log("Unzipped and written file: " + filename);
-              if (callback != null) {
-                return callback();
-              }
-            });
-          } catch (error1) {
-            err = error1;
-            console.error(err);
-            return console.log(filename + ".meta");
-          }
+          var writeUnziipedFile;
+          return writeUnziipedFile = function(properties) {
+            var writeData;
+            writeData = {
+              project: project.id,
+              file: filename,
+              content: fileContent,
+              request_id: -data.request_id,
+              properties: properties
+            };
+            _this.writeProjectFile(writeData);
+            console.log("Unzipped and written file: " + filename);
+            if (callback != null) {
+              return callback();
+            }
+          };
         };
       })(this));
+      try {
+        if (zip.file(filename + ".meta") != null) {
+          return zip.file(filename + ".meta").async("string").then((function(_this) {
+            return function(meta) {
+              var metaJson;
+              metaJson = JSON.parse(meta);
+              return writeUnziipedFile(metaJson.properties);
+            };
+          })(this));
+        } else {
+          console.log("Meta file for file " + filename + " does not exist, no properties added to the file");
+          return writeUnziipedFile({});
+        }
+      } catch (error1) {
+        err = error1;
+        console.error(err);
+        return console.log(filename + ".meta");
+      }
     } catch (error1) {
       err = error1;
       console.error(err);

--- a/server/session/session.js
+++ b/server/session/session.js
@@ -708,10 +708,8 @@ this.Session = (function() {
                 value = ref[filename];
                 files.push(filename);
               }
-              console.log("[ZIP] Files added the list. Amount of files: " + files.length);
               funk = function() {
                 var properties;
-                console.log("[ZIP] Files to process: " + files.length);
                 if (files.length > 0) {
                   filename = files.splice(0, 1)[0];
                   value = contents.files[filename];
@@ -727,7 +725,6 @@ this.Session = (function() {
                       properties: properties,
                       request_id: request_id
                     };
-                    console.log("[ZIP] Processing file: " + filename);
                     if (value.dir) {
                       return funk();
                     } else if (filename === projectFileName) {
@@ -759,7 +756,6 @@ this.Session = (function() {
                     }
                   })(filename, value);
                 } else {
-                  console.log("[ZIP] All files processed!");
                   return _this.send({
                     name: "project_imported",
                     id: project_id,
@@ -790,7 +786,6 @@ this.Session = (function() {
             properties: import_data.properties
           };
           _this.writeProjectFile(writeData);
-          console.log("Unzipped and written file: " + import_data.filename);
           if (callback != null) {
             return callback();
           }
@@ -811,7 +806,6 @@ this.Session = (function() {
           var buffer;
           buffer = Buffer.from(fileContent, "base64");
           return _this.content.files.write(_this.user.id + "/" + import_data.project_id + "/" + import_data.filename, buffer, function() {
-            console.log("Unzipped and created file: " + import_data.filename);
             if (callback != null) {
               return callback();
             }

--- a/server/session/session.js
+++ b/server/session/session.js
@@ -680,6 +680,9 @@ this.Session = (function() {
     if (!this.server.rate_limiter.accept("import_project_user", this.user.id)) {
       return;
     }
+    if (!data.zip_data.startsWith("data:application/x-zip-compressed;base64,")) {
+      return;
+    }
     buffer = new Buffer.from(data.zip_data.replace("data:application/x-zip-compressed;base64,", ""), 'base64');
     queue = new JobQueue((function(_this) {
       return function() {

--- a/server/session/session.js
+++ b/server/session/session.js
@@ -689,6 +689,10 @@ this.Session = (function() {
         var zip;
         zip = new JSZip;
         return zip.loadAsync(buffer).then(function(contents) {
+          if (zip.file("project.meta") == null) {
+            console.log("[ZIP] Missing project.meta; import aborted");
+            return;
+          }
           return zip.file("project.meta").async("string").then(function(text) {
             var projectInfo;
             projectInfo = JSON.parse(text);

--- a/static/js/app.coffee
+++ b/static/js/app.coffee
@@ -155,6 +155,7 @@ class App
           console.info "processing #{file.name}"
           reader = new FileReader()
           reader.addEventListener "load",()=>
+            return if not reader.result.startsWith("data:application/x-zip-compressed;base64,")
             @client.sendRequest {
               name: "import_project"
               user: @nick

--- a/static/js/app.coffee
+++ b/static/js/app.coffee
@@ -143,6 +143,28 @@ class App
 
       return
 
+  importProject:(files)->
+    try
+      list = []
+      for i in files
+        list.push i.getAsFile()
+
+      funk = ()=>
+        if list.length>0
+          file = list.splice(0,1)[0]
+          console.info "processing #{file.name}"
+          reader = new FileReader()
+          reader.addEventListener "load",()=>
+            @client.sendRequest
+              name: "import_project"
+              user: @nick
+              zip_data: reader.result
+
+          reader.readAsDataURL(file)
+      funk()
+    catch err
+      console.error err
+
   updateProjectList:(open_when_fetched)->
     @getProjectList (list)=>
       @projects = list

--- a/static/js/app.coffee
+++ b/static/js/app.coffee
@@ -155,10 +155,25 @@ class App
           console.info "processing #{file.name}"
           reader = new FileReader()
           reader.addEventListener "load",()=>
-            @client.sendRequest
+            @client.sendRequest {
               name: "import_project"
               user: @nick
               zip_data: reader.result
+            },(msg)=>
+              console.log "[ZIP] #{msg.name}"
+              switch msg.name
+                when "error"
+                  console.error msg.error
+                  alert @translator.get(msg.error) if msg.error?
+
+                when "project_imported"
+                  @getProjectList (list)=>
+                    @projects = list
+                    @appui.updateProjects()
+                    # for p in list
+                    #   if p.id == msg.id
+                    #     @openProject p
+                    #     callback() if callback?
 
           reader.readAsDataURL(file)
       funk()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -109,7 +109,7 @@ App = (function() {
       password: password
     }, (function(_this) {
       return function(msg) {
-        var i, len, n, ref;
+        var j, len, n, ref;
         switch (msg.name) {
           case "error":
             console.error(msg.error);
@@ -129,8 +129,8 @@ App = (function() {
             };
             if ((msg.notifications != null) && msg.notifications.length > 0) {
               ref = msg.notifications;
-              for (i = 0, len = ref.length; i < len; i++) {
-                n = ref[i];
+              for (j = 0, len = ref.length; j < len; j++) {
+                n = ref[j];
                 _this.appui.showNotification(n);
               }
             }
@@ -176,12 +176,12 @@ App = (function() {
             break;
           case "project_created":
             _this.getProjectList(function(list) {
-              var i, len, p, results;
+              var j, len, p, results;
               _this.projects = list;
               _this.appui.updateProjects();
               results = [];
-              for (i = 0, len = list.length; i < len; i++) {
-                p = list[i];
+              for (j = 0, len = list.length; j < len; j++) {
+                p = list[j];
                 if (p.id === msg.id) {
                   _this.openProject(p);
                   if (callback != null) {
@@ -200,17 +200,50 @@ App = (function() {
     })(this));
   };
 
+  App.prototype.importProject = function(files) {
+    var err, funk, i, j, len, list;
+    try {
+      list = [];
+      for (j = 0, len = files.length; j < len; j++) {
+        i = files[j];
+        list.push(i.getAsFile());
+      }
+      funk = (function(_this) {
+        return function() {
+          var file, reader;
+          if (list.length > 0) {
+            file = list.splice(0, 1)[0];
+            console.info("processing " + file.name);
+            reader = new FileReader();
+            reader.addEventListener("load", function() {
+              return _this.client.sendRequest({
+                name: "import_project",
+                user: _this.nick,
+                zip_data: reader.result
+              });
+            });
+            return reader.readAsDataURL(file);
+          }
+        };
+      })(this);
+      return funk();
+    } catch (error) {
+      err = error;
+      return console.error(err);
+    }
+  };
+
   App.prototype.updateProjectList = function(open_when_fetched) {
     return this.getProjectList((function(_this) {
       return function(list) {
-        var i, len, p, ref, results;
+        var j, len, p, ref, results;
         _this.projects = list;
         _this.appui.updateProjects();
         if (open_when_fetched != null) {
           ref = _this.projects;
           results = [];
-          for (i = 0, len = ref.length; i < len; i++) {
-            p = ref[i];
+          for (j = 0, len = ref.length; j < len; j++) {
+            p = ref[j];
             if (p.id === open_when_fetched) {
               _this.openProject(p);
               break;
@@ -289,13 +322,13 @@ App = (function() {
   };
 
   App.prototype.projectTitleExists = function(title) {
-    var i, len, p, ref;
+    var j, len, p, ref;
     if (!this.projects) {
       return false;
     }
     ref = this.projects;
-    for (i = 0, len = ref.length; i < len; i++) {
-      p = ref[i];
+    for (j = 0, len = ref.length; j < len; j++) {
+      p = ref[j];
       if (p.title === title) {
         return true;
       }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -220,6 +220,21 @@ App = (function() {
                 name: "import_project",
                 user: _this.nick,
                 zip_data: reader.result
+              }, function(msg) {
+                console.log("[ZIP] " + msg.name);
+                switch (msg.name) {
+                  case "error":
+                    console.error(msg.error);
+                    if (msg.error != null) {
+                      return alert(_this.translator.get(msg.error));
+                    }
+                    break;
+                  case "project_imported":
+                    return _this.getProjectList(function(list) {
+                      _this.projects = list;
+                      return _this.appui.updateProjects();
+                    });
+                }
               });
             });
             return reader.readAsDataURL(file);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -216,6 +216,9 @@ App = (function() {
             console.info("processing " + file.name);
             reader = new FileReader();
             reader.addEventListener("load", function() {
+              if (!reader.result.startsWith("data:application/x-zip-compressed;base64,")) {
+                return;
+              }
               return _this.client.sendRequest({
                 name: "import_project",
                 user: _this.nick,

--- a/static/js/appui/appui.coffee
+++ b/static/js/appui/appui.coffee
@@ -133,6 +133,35 @@ class AppUI
       #document.querySelector("#home-section .part1").style["padding-top"] = "#{160-scroll}px"
 
 
+    document.getElementById("myprojects").addEventListener "dragover",(event)=>
+      event.preventDefault()
+
+    document.getElementById("myprojects").addEventListener "drop",(event)=>
+      event.preventDefault()
+      try
+        list = []
+        for i in event.dataTransfer.items
+          list.push i.getAsFile()
+
+        funk = ()=>
+          if list.length>0
+            file = list.splice(0,1)[0]
+            console.info "processing #{file.name}"
+            
+            reader = new FileReader()
+            reader.addEventListener "load",()=>
+              @app.client.sendRequest
+                name: "import_project"
+                user: @app.nick
+                zip_data: reader.result
+
+            reader.readAsDataURL(file)
+ 
+        funk()
+
+      catch err
+        console.error err
+
     setInterval (()=>@checkActivity()),10000
 
     @reboot_date = 1622710800000

--- a/static/js/appui/appui.coffee
+++ b/static/js/appui/appui.coffee
@@ -138,29 +138,7 @@ class AppUI
 
     document.getElementById("myprojects").addEventListener "drop",(event)=>
       event.preventDefault()
-      try
-        list = []
-        for i in event.dataTransfer.items
-          list.push i.getAsFile()
-
-        funk = ()=>
-          if list.length>0
-            file = list.splice(0,1)[0]
-            console.info "processing #{file.name}"
-            
-            reader = new FileReader()
-            reader.addEventListener "load",()=>
-              @app.client.sendRequest
-                name: "import_project"
-                user: @app.nick
-                zip_data: reader.result
-
-            reader.readAsDataURL(file)
- 
-        funk()
-
-      catch err
-        console.error err
+      @app.importProject(event.dataTransfer.items)
 
     setInterval (()=>@checkActivity()),10000
 

--- a/static/js/appui/appui.js
+++ b/static/js/appui/appui.js
@@ -179,36 +179,8 @@ AppUI = (function() {
     })(this));
     document.getElementById("myprojects").addEventListener("drop", (function(_this) {
       return function(event) {
-        var err, funk, i, l, len2, list, ref2;
         event.preventDefault();
-        try {
-          list = [];
-          ref2 = event.dataTransfer.items;
-          for (l = 0, len2 = ref2.length; l < len2; l++) {
-            i = ref2[l];
-            list.push(i.getAsFile());
-          }
-          funk = function() {
-            var file, reader;
-            if (list.length > 0) {
-              file = list.splice(0, 1)[0];
-              console.info("processing " + file.name);
-              reader = new FileReader();
-              reader.addEventListener("load", function() {
-                return _this.app.client.sendRequest({
-                  name: "import_project",
-                  user: _this.app.nick,
-                  zip_data: reader.result
-                });
-              });
-              return reader.readAsDataURL(file);
-            }
-          };
-          return funk();
-        } catch (error) {
-          err = error;
-          return console.error(err);
-        }
+        return _this.app.importProject(event.dataTransfer.items);
       };
     })(this));
     setInterval(((function(_this) {

--- a/static/js/appui/appui.js
+++ b/static/js/appui/appui.js
@@ -172,6 +172,45 @@ AppUI = (function() {
         return document.querySelector("#home-header-background").style.height = scroll + "px";
       };
     })(this));
+    document.getElementById("myprojects").addEventListener("dragover", (function(_this) {
+      return function(event) {
+        return event.preventDefault();
+      };
+    })(this));
+    document.getElementById("myprojects").addEventListener("drop", (function(_this) {
+      return function(event) {
+        var err, funk, i, l, len2, list, ref2;
+        event.preventDefault();
+        try {
+          list = [];
+          ref2 = event.dataTransfer.items;
+          for (l = 0, len2 = ref2.length; l < len2; l++) {
+            i = ref2[l];
+            list.push(i.getAsFile());
+          }
+          funk = function() {
+            var file, reader;
+            if (list.length > 0) {
+              file = list.splice(0, 1)[0];
+              console.info("processing " + file.name);
+              reader = new FileReader();
+              reader.addEventListener("load", function() {
+                return _this.app.client.sendRequest({
+                  name: "import_project",
+                  user: _this.app.nick,
+                  zip_data: reader.result
+                });
+              });
+              return reader.readAsDataURL(file);
+            }
+          };
+          return funk();
+        } catch (error) {
+          err = error;
+          return console.error(err);
+        }
+      };
+    })(this));
     setInterval(((function(_this) {
       return function() {
         return _this.checkActivity();


### PR DESCRIPTION
This change makes it possible to import projects by dragging ZIP file with the project on "My projects" list. It uses file format that is produced by export feature introduced in #5. The import produces new project.

Preview of the feature:
https://user-images.githubusercontent.com/616373/126042177-0cedd59f-54cf-47c6-8260-12850d2eb42f.mp4

It sends the whole archive via websocket and unzips it on the server. I considered unzipping on the client and sending files one by one, but I thought it might be better to send it as a whole package To have all or nothing in case of any interruption in uploading. It was not yet tested against archives with bigger projects.

I make this pull request as draft, as there are some things I want to add before it is merged:
- ability to import for users with verified emails only
- file size limit
- maybe requirement for being a user on microStudio for X hours/days to use this feature
- visual indicator that there is an option of importing the project

At first I thought about ability to update existing project, if the slug is the same as the imported one, but it leads to so many edge cases and possible data losses, that I decided to always create a new project instead.
