### PR TITLE
Change project and tutorial source file icon to fa-file-code

### DIFF
--- a/static/js/editor/editor.coffee
+++ b/static/js/editor/editor.coffee
@@ -454,7 +454,7 @@ class @Editor
     list = document.getElementById("source-list").childNodes
 
     if @selected_source?
-      document.getElementById("code-toolbar").innerHTML = "<i class='fa fa-file'></i> "+@selected_source
+      document.getElementById("code-toolbar").innerHTML = "<i class='fa fa-file-code'></i> "+@selected_source
       for e in list
         if e.getAttribute("id") == "source-list-item-#{name}"
           e.classList.add("selected")
@@ -569,7 +569,7 @@ class @Editor
 
     i = document.createElement "i"
     i.classList.add "fa"
-    i.classList.add "fa-file"
+    i.classList.add "fa-file-code"
     element.appendChild i
 
     span = document.createElement "div"

--- a/static/js/editor/editor.js
+++ b/static/js/editor/editor.js
@@ -642,7 +642,7 @@ this.Editor = (function() {
     this.selected_source = name;
     list = document.getElementById("source-list").childNodes;
     if (this.selected_source != null) {
-      document.getElementById("code-toolbar").innerHTML = "<i class='fa fa-file'></i> " + this.selected_source;
+      document.getElementById("code-toolbar").innerHTML = "<i class='fa fa-file-code'></i> " + this.selected_source;
       for (j = 0, len = list.length; j < len; j++) {
         e = list[j];
         if (e.getAttribute("id") === ("source-list-item-" + name)) {
@@ -777,7 +777,7 @@ this.Editor = (function() {
     element.appendChild(tools);
     i = document.createElement("i");
     i.classList.add("fa");
-    i.classList.add("fa-file");
+    i.classList.add("fa-file-code");
     element.appendChild(i);
     span = document.createElement("div");
     span.classList.add("filename");

--- a/static/js/explore/projectdetails.coffee
+++ b/static/js/explore/projectdetails.coffee
@@ -208,7 +208,7 @@ class @ProjectDetails
     },(msg)=>
       @sources[file] = msg.content
       div = document.createElement "div"
-      div.innerHTML = "<i class='fa fa-file'></i> #{file.split(".")[0]}"
+      div.innerHTML = "<i class='fa fa-file-code'></i> #{file.split(".")[0]}"
       document.querySelector("#project-contents-view .code-list").appendChild div
       div.id = "project-contents-view-source-#{file}"
       div.addEventListener "click",()=>@setSelectedSource(file)

--- a/static/js/explore/projectdetails.js
+++ b/static/js/explore/projectdetails.js
@@ -259,7 +259,7 @@ this.ProjectDetails = (function() {
         var div;
         _this.sources[file] = msg.content;
         div = document.createElement("div");
-        div.innerHTML = "<i class='fa fa-file'></i> " + (file.split(".")[0]);
+        div.innerHTML = "<i class='fa fa-file-code'></i> " + (file.split(".")[0]);
         document.querySelector("#project-contents-view .code-list").appendChild(div);
         div.id = "project-contents-view-source-" + file;
         div.addEventListener("click", function() {

--- a/static/js/tutorial/tutorials.coffee
+++ b/static/js/tutorial/tutorials.coffee
@@ -103,7 +103,7 @@ class @Tutorials
 
     code = document.createElement "i"
     code.classList.add "fas"
-    code.classList.add "fa-file"
+    code.classList.add "fa-file-code"
     a.appendChild code
     li.appendChild a
 

--- a/static/js/tutorial/tutorials.js
+++ b/static/js/tutorial/tutorials.js
@@ -127,7 +127,7 @@ this.Tutorials = (function() {
     a.title = this.app.translator.get("View tutorial source code");
     code = document.createElement("i");
     code.classList.add("fas");
-    code.classList.add("fa-file");
+    code.classList.add("fa-file-code");
     a.appendChild(code);
     li.appendChild(a);
     a.addEventListener("click", (function(_this) {


### PR DESCRIPTION
Minor change - I always felt that the icon of code file looks like it is not recognized by the editor, so it's just "empty file" icon. That's why I changed the icon for source code files from `fa-file` to `fa-file-code`. It corresponds well with the icon used for the code section.

Current version:
![obraz](https://user-images.githubusercontent.com/616373/126080732-8c6b8798-7217-4431-a87c-702d5ad5f889.png)

New version preview:
![obraz](https://user-images.githubusercontent.com/616373/126080804-51c0bbe5-410a-48da-ab41-7b8b6d838324.png)
