### PR TITLE
Fix visibility of advanced project creation options

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1626,6 +1626,7 @@ padding-left: 2px ;
 
 .createprojectoption select option {
   background-color: hsl(200,50%,10%);
+  color: #FFF;
   padding: 2px ;
 }
 


### PR DESCRIPTION
I checked advanced options for creating project in both Firefox and Chrome and I see black text on dark background when I click on the dropdowns:
![image](https://user-images.githubusercontent.com/616373/147074366-04f94136-6fb9-4b7c-af30-6528e1cb2b77.png)

This change simply sets text color for those options to white:
![image](https://user-images.githubusercontent.com/616373/147074558-975585cb-3857-4a87-8cd5-9aa84797b997.png)
