### PR TITLE
Add scrolling to sprite toolbar

### DIFF
--- a/static/css/sprites.css
+++ b/static/css/sprites.css
@@ -136,9 +136,12 @@
   position: absolute ;
   left: 58px ;
   top: 0 ;
-  bottom: 0 ;
+  /* Space for spritehelpers */
+  bottom: 60px ;
   right: 0 ;
   padding: 8px ;
+  overflow-x: hidden ;
+  overflow-y: auto ;
 }
 
 .spritetooloptions input {
@@ -355,7 +358,7 @@
 /*  margin-top: 20px;*/
 }
 .colorpicker canvas {
-  /*width: 100% ;*/
+  width: 100% ;
   cursor: pointer ;
 }
 .spriteeditor canvas {
@@ -416,7 +419,6 @@
   text-align: center;
   background: hsla(200,40%,80%,.8);
   box-sizing: border-box;
-  width: 146px ;
   border-radius: 5px;
   border: none ;
   padding: 5px 5px 5px 10px ;
@@ -439,7 +441,8 @@
 }
 
 #colorpicker-group .spritetoolbutton {
-  width: 140px ;
+  width: 100% ;
+  box-sizing: border-box ;
   margin: 2px 0 ;
 }
 #sprite-animation-panel {


### PR DESCRIPTION
In small screens you will now be able to scroll down if the sprite tool
options is cut off.

Before: 
<img width="291" alt="image" src="https://user-images.githubusercontent.com/35302428/155419109-20608460-0ec7-4f32-b469-ae815d42c426.png">

https://user-images.githubusercontent.com/35302428/155422054-375df291-c61d-40b5-89c5-751a52a44e2b.mov

After:

<img width="260" alt="image" src="https://user-images.githubusercontent.com/35302428/155419161-1250555d-1ca2-41aa-ad44-6bce35ffc8fb.png">

https://user-images.githubusercontent.com/35302428/155422025-eaaa692b-ded5-498b-ad59-eca6c30934f8.mov


By increasing sprite tool options 'bottom' attribute, I changed the height of
the sprite tool options so it doesn't fade behind the sprite helpers.
This also makes it so the scroll bar won't cover up part of the H
Symmetry button.

All items in the sprite tool options decrease in size to make room for
the toolbar automatically.

A little annoying quirk is that decreasing the size of your window will
cause the scroll bar to appear but then it will also decrease the size
of the elements so the scroll bar is unnecessary and it will be a weird
empty scroll bar until you decrease the size of the window further for
it to be necessary again.

In the future it could be nice to center the sprite tool options where
it is, since the left padding looks larger than the right padding. I
think that just means changing the left distance attribute from 58px to 52px.