### PR TITLE
Remove extraneous comma that breaks `npm run dev`.

### DIFF
--- a/server/webapp.coffee
+++ b/server/webapp.coffee
@@ -44,7 +44,7 @@ class @WebApp
       if i==@languages.length-1
         home_exp += "|"
 
-    @reserved = ["explore","documentation","projects","about","login","user","tutorials\\/examples",,"tutorials\\/community"]
+    @reserved = ["explore","documentation","projects","about","login","user","tutorials\\/examples","tutorials\\/community"]
     @reserved_exact = ["tutorials"]
 
     for r in @reserved


### PR DESCRIPTION
Resolves this error:
```
λ npm run dev

> microstudio@1.0.0 dev
> npm run compile && concurrently "npm:compile-and-watch" "npm:start"


> microstudio@1.0.0 compile
> coffee -c --no-header -b ../.

/Users/ryanmcquen/code/microstudio/server/webapp.coffee:47:101: error: unexpected ,
    @reserved = ["explore","documentation","projects","about","login","user","tutorials\\/examples",,"tutorials\\/community"]
                                                                                                    ^
```

Related to:
https://github.com/pmgl/microstudio/issues/224