### PR TITLE
perf(engine): cache compiled routines in Thread.loadNext()

### DIFF
--- a/static/js/languages/microscript/v2/runner.coffee
+++ b/static/js/languages/microscript/v2/runner.coffee
@@ -256,6 +256,7 @@ class @Thread
     @paused = false
     @terminated = false
     @next_calls = []
+    @call_cache = new Map()
     @interface =
       pause: ()=>@pause()
       resume: ()=>@resume()
@@ -272,11 +273,16 @@ class @Thread
       if f instanceof Routine
         @processor.load f
       else
-        parser = new Parser(f,"")
-        parser.parse()
-        program = parser.program
-        compiler = new Compiler(program)
-        @processor.load compiler.routine
+        cached = @call_cache.get(f)
+        if cached?
+          @processor.load cached
+        else
+          parser = new Parser(f,"")
+          parser.parse()
+          program = parser.program
+          compiler = new Compiler(program)
+          @call_cache.set f, compiler.routine
+          @processor.load compiler.routine
         if (f == "update()" or f == "serverUpdate()") and @runner.updateControls?
           @runner.updateControls()
       true

--- a/static/js/languages/microscript/v2/runner.js
+++ b/static/js/languages/microscript/v2/runner.js
@@ -314,6 +314,7 @@ this.Thread = class Thread {
     this.paused = false;
     this.terminated = false;
     this.next_calls = [];
+    this.call_cache = new Map();
     this.interface = {
       pause: () => {
         return this.pause();
@@ -335,17 +336,23 @@ this.Thread = class Thread {
   }
 
   loadNext() {
-    var compiler, f, parser, program;
+    var cached, compiler, f, parser, program;
     if (this.next_calls.length > 0) {
       f = this.next_calls.splice(0, 1)[0];
       if (f instanceof Routine) {
         this.processor.load(f);
       } else {
-        parser = new Parser(f, "");
-        parser.parse();
-        program = parser.program;
-        compiler = new Compiler(program);
-        this.processor.load(compiler.routine);
+        cached = this.call_cache.get(f);
+        if (cached != null) {
+          this.processor.load(cached);
+        } else {
+          parser = new Parser(f, "");
+          parser.parse();
+          program = parser.program;
+          compiler = new Compiler(program);
+          this.call_cache.set(f, compiler.routine);
+          this.processor.load(compiler.routine);
+        }
         if ((f === "update()" || f === "serverUpdate()") && (this.runner.updateControls != null)) {
           this.runner.updateControls();
         }


### PR DESCRIPTION
# perf(engine): cache compiled routines in Thread.loadNext()

## Summary

Fixes a critical per-frame performance bottleneck in the microScript v2 runtime engine. `Thread.loadNext()` was re-parsing and re-compiling call strings like `"update()"` and `"draw()"` every single frame, despite the strings never changing.

## Problem

At 60fps, `loadNext()` creates **120+ full parse→compile cycles per second** for static call strings. Each cycle allocates:

- A `Tokenizer` with lookup tables
- A `Parser` with `api_reserved` arrays
- AST nodes
- A `Compiler` with opcodes arrays and label maps

All of these objects are immediately garbage collected, creating unnecessary GC pressure and wasted CPU time.

## Solution

Added a `Map<string, Routine>` cache (`call_cache`) to `Thread`. On the first encounter of a call string, the parse→compile path runs as before, then stores the compiled `Routine` in the cache. On subsequent frames, the cached `Routine` is returned directly via `Map.get()`, bypassing the entire pipeline.

### Why this is safe

The cached routines compile to "call by name" instructions — they resolve the actual function body at runtime via `context.global`. When user source code changes, `context.global.update` (etc.) is updated by `Runner.run()`, so the cached routine automatically picks up the new function body without cache invalidation.

The cache is scoped to `Thread` lifetime — new game sessions create a new `MicroVM` → `Runner` → `Thread` → fresh cache.

## Benchmark Results (Vitest/Tinybench)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Single call `"update()"` | 641,228 ops/sec | 18,482,921 ops/sec | **~29x faster** |
| Full frame (update+draw) | 375,660 ops/sec | 17,222,238 ops/sec | **~46x faster** |
| Per-frame cost at 60fps | ~162µs/sec | ~3.5µs/sec | **~46x less overhead** |
| GC pressure | 120+ allocs/sec | 0 after warm-up | **Eliminated** |

## Files Changed

- `static/js/languages/microscript/v2/runner.coffee` — CoffeeScript source
- `static/js/languages/microscript/v2/runner.js` — compiled JS output

## Testing

- Vitest benchmark suite confirms performance improvement
- `runner.coffee` compiles cleanly with CoffeeScript
- Compiled output matches the manually maintained `.js` file logic

## Benchmark Suite (patch included)

A full Vitest/Tinybench benchmark suite is available as a separate patch file (`benchmarks.patch`). It includes:

- 10 benchmark suites covering the microScript v2 pipeline (tokenizer, parser, compiler, processor, pipeline) and 30 identified bottlenecks
- Baseline and post-fix benchmark results (`benchmark_baseline.md`, `benchmark_postfix.md`)
- Bottleneck analysis (`possible_bottlenecks.md`)
- Setup and helpers for loading microScript source files in Node.js via `vm.Script`

To apply:
```bash
git apply benchmarks.patch
cd benchmarks && npm install

npx vitest bench --run
```
[benchmarks.patch](https://github.com/user-attachments/files/25354063/benchmarks.patch)
