### PR TITLE
Security: Relay token check executes callback before verification (authentication bypass)

### DIFF
--- a/server/relay/relay.js
+++ b/server/relay/relay.js
@@ -44,8 +44,13 @@ Relay = class Relay {
         try {
           data = JSON.parse(msg.data);
           if (data.name === "check_server_token") {
-            if (data.valid && (this.token_requests[data.token] != null)) {
-              this.token_requests[data.token]();
+            if (this.token_requests[data.token] != null) {
+              if (data.valid && (typeof this.token_requests[data.token].callback === "function")) {
+                this.token_requests[data.token].callback();
+              }
+              if (this.token_requests[data.token].timeout != null) {
+                clearTimeout(this.token_requests[data.token].timeout);
+              }
               return delete this.token_requests[data.token];
             }
           }
@@ -94,7 +99,14 @@ Relay = class Relay {
   }
 
   serverTokenCheck(token, server_id, callback) {
-    this.token_requests[token] = callback();
+    var request;
+    request = {
+      callback: callback
+    };
+    request.timeout = setTimeout((() => {
+      return delete this.token_requests[token];
+    }), 30000);
+    this.token_requests[token] = request;
     return this.client.send(JSON.stringify({
       name: "check_server_token",
       server_id: server_id,


### PR DESCRIPTION
## Problem

In `serverTokenCheck`, the callback is invoked immediately (`callback()`) and its return value is stored, instead of storing the callback function. This means server startup/authenticated actions can run before token validation response is received, allowing unauthorized relay server registration/usage.

**Severity**: `critical`
**File**: `server/relay/relay.js`

## Solution

Store the callback function reference without invoking it (e.g., `this.token_requests[token] = callback;`) and only execute it after receiving a positive `check_server_token` response. Also add expiry/one-time semantics for pending token requests.

## Changes

- `server/relay/relay.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
